### PR TITLE
Add notes screen and hidden capy buttons

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -11,6 +11,7 @@ import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 import os from "node:os";
+import fs from "node:fs";
 import { update } from "./update";
 
 const require = createRequire(import.meta.url);
@@ -35,6 +36,13 @@ if (!app.requestSingleInstanceLock()) {
 let win: BrowserWindow | null = null;
 const preload = path.join(__dirname, "../preload/index.mjs");
 const indexHtml = path.join(RENDERER_DIST, "index.html");
+
+const notesDir = path.join(process.env.APP_ROOT, "userData", "notes");
+function ensureNotesDir() {
+  if (!fs.existsSync(notesDir)) {
+    fs.mkdirSync(notesDir, { recursive: true });
+  }
+}
 
 let currentMode: "transparent" | "normal" | "hidden" = "normal";
 let currentCorner: "right" | "left" = "right";
@@ -136,7 +144,10 @@ async function createWindow(
   update(win);
 }
 
-app.whenReady().then(() => createWindow(currentMode));
+app.whenReady().then(() => {
+  ensureNotesDir();
+  createWindow(currentMode);
+});
 
 app.on("window-all-closed", () => {
   win = null;
@@ -332,3 +343,40 @@ const backToNormalMode = async () => {
   win.webContents.send("update-is-transparent", false); // Envia mensagem para atualizar o estado
 };
 ipcMain.handle("set-normal-mode", backToNormalMode);
+
+ipcMain.handle("notes-list", () => {
+  ensureNotesDir();
+  const files = fs
+    .readdirSync(notesDir)
+    .filter((f) => f.endsWith(".md"))
+    .map((f) => {
+      const stat = fs.statSync(path.join(notesDir, f));
+      return { title: path.basename(f, ".md"), mtime: stat.mtime.getTime() };
+    })
+    .sort((a, b) => b.mtime - a.mtime);
+  return files;
+});
+
+const sanitize = (t: string) => t.replace(/[^a-z0-9-_ ]/gi, "_");
+
+ipcMain.handle("notes-read", (_, title: string) => {
+  ensureNotesDir();
+  const file = path.join(notesDir, sanitize(title) + ".md");
+  try {
+    return fs.readFileSync(file, "utf8");
+  } catch {
+    return "";
+  }
+});
+
+ipcMain.handle("notes-save", (_, title: string, content: string) => {
+  ensureNotesDir();
+  const file = path.join(notesDir, sanitize(title) + ".md");
+  fs.writeFileSync(file, content, "utf8");
+});
+
+ipcMain.handle("notes-delete", (_, title: string) => {
+  ensureNotesDir();
+  const file = path.join(notesDir, sanitize(title) + ".md");
+  if (fs.existsSync(file)) fs.unlinkSync(file);
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import App from "./App";
 import Home from "./screens/home/home";
 import Welcome from "./screens/welcome/welcome";
+import Notes from "./screens/notes/notes";
 import { BrowserRouter, Route, Routes } from "react-router";
 import { SystemStateProvider } from "./context/systemStateContext";
 
@@ -21,6 +22,7 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
           <Route path="/" element={<Welcome />} />
           <Route path="/home" element={<Home />} />
           <Route path="/closet" element={<Closet />} />
+          <Route path="/notes" element={<Notes />} />
           <Route path="/app" element={<App />} />
         </Routes>
       </BrowserRouter>

--- a/src/screens/home/hidden-capy/hidden-capy.tsx
+++ b/src/screens/home/hidden-capy/hidden-capy.tsx
@@ -1,6 +1,11 @@
 import React, { useState, useEffect } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faRightFromBracket } from "@fortawesome/free-solid-svg-icons";
+import {
+  faRightFromBracket,
+  faNoteSticky,
+  faCircle,
+} from "@fortawesome/free-solid-svg-icons";
+import { useNavigate } from "react-router";
 import { useSystemState } from "@/context/systemStateContext";
 
 interface HiddenCapyProps {
@@ -15,6 +20,7 @@ const HiddenCapy: React.FC<HiddenCapyProps> = ({
   handleHideCapy,
 }) => {
   const [showButton, setShowButton] = useState(false);
+  const navigate = useNavigate();
   const {
     currentCorner,
     handleMouseEnter,
@@ -72,20 +78,56 @@ const HiddenCapy: React.FC<HiddenCapyProps> = ({
         }}
       >
         {showButton && (
-          <button
-            className="absolute right-8 top-10 bg-gray-200 p-2 h-8 rounded-full shadow-md hover:bg-gray-300 rotate-180 z-20"
-            onClick={() => handleHideCapy("transparent")}
-            onMouseEnter={() => {
-              handleMouseEnter();
-              setShowButton(true);
-            }}
-            onMouseLeave={() => {
-              handleMouseLeave();
-              setShowButton(false);
-            }}
-          >
-            <FontAwesomeIcon icon={faRightFromBracket} />
-          </button>
+          <>
+            <button
+              className="absolute bg-gray-200 p-2 h-8 rounded-full shadow-md hover:bg-gray-300 rotate-180 z-20"
+              style={{ right: 28, top: -24 }}
+              onClick={() => {}}
+              onMouseEnter={() => {
+                handleMouseEnter();
+                setShowButton(true);
+              }}
+              onMouseLeave={() => {
+                handleMouseLeave();
+                setShowButton(false);
+              }}
+            >
+              <FontAwesomeIcon icon={faCircle} />
+            </button>
+            <button
+              className="absolute bg-gray-200 p-2 h-8 rounded-full shadow-md hover:bg-gray-300 rotate-180 z-20"
+              style={{ right: 14, top: -10 }}
+              onClick={() => {
+                handleHideCapy("normal");
+                navigate("/notes");
+              }}
+              onMouseEnter={() => {
+                handleMouseEnter();
+                setShowButton(true);
+              }}
+              onMouseLeave={() => {
+                handleMouseLeave();
+                setShowButton(false);
+              }}
+            >
+              <FontAwesomeIcon icon={faNoteSticky} />
+            </button>
+            <button
+              className="absolute bg-gray-200 p-2 h-8 rounded-full shadow-md hover:bg-gray-300 rotate-180 z-20"
+              style={{ right: 8, top: 10 }}
+              onClick={() => handleHideCapy("transparent")}
+              onMouseEnter={() => {
+                handleMouseEnter();
+                setShowButton(true);
+              }}
+              onMouseLeave={() => {
+                handleMouseLeave();
+                setShowButton(false);
+              }}
+            >
+              <FontAwesomeIcon icon={faRightFromBracket} />
+            </button>
+          </>
         )}
         <img
           src={hiddenCapibaraImage}

--- a/src/screens/notes/notes.tsx
+++ b/src/screens/notes/notes.tsx
@@ -1,0 +1,139 @@
+import React, { useEffect, useState } from "react";
+import HeaderFrame from "@/components/headerFrame/headerFrame";
+import { useSystemState } from "@/context/systemStateContext";
+import { useNavigate } from "react-router";
+import Modal from "@/components/update/Modal";
+
+interface NoteMeta {
+  title: string;
+  mtime: number;
+}
+
+const Notes: React.FC = () => {
+  const [notes, setNotes] = useState<NoteMeta[]>([]);
+  const [currentTitle, setCurrentTitle] = useState("");
+  const [content, setContent] = useState("");
+  const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+  const navigate = useNavigate();
+  const { toggleSize } = useSystemState();
+
+  useEffect(() => {
+    toggleSize(720, 720);
+    fetchNotes();
+  }, []);
+
+  const fetchNotes = async () => {
+    const list = await window.ipcRenderer.invoke("notes-list");
+    setNotes(list);
+    if (list.length > 0) {
+      openNote(list[0].title);
+    }
+  };
+
+  const openNote = async (title: string) => {
+    const text = await window.ipcRenderer.invoke("notes-read", title);
+    setCurrentTitle(title);
+    setContent(text);
+  };
+
+  const handleSave = async () => {
+    if (!currentTitle.trim()) return;
+    await window.ipcRenderer.invoke("notes-save", currentTitle, content);
+    fetchNotes();
+  };
+
+  const handleAdd = () => {
+    setCurrentTitle("New Note");
+    setContent("");
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    await window.ipcRenderer.invoke("notes-delete", deleteTarget);
+    setDeleteTarget(null);
+    if (currentTitle === deleteTarget) {
+      setCurrentTitle("");
+      setContent("");
+    }
+    fetchNotes();
+  };
+
+  const handleBack = () => {
+    navigate("/home");
+  };
+
+  return (
+    <div className="bg-[#c78f40] overflow-hidden h-full">
+      <HeaderFrame />
+      <div className="flex flex-col h-full pt-10 px-4 pb-4">
+        <button
+          onClick={handleBack}
+          className="bg-transparent font-sans cursor-pointer font-bold text-xl mt-6 absolute top-4 left-4"
+        >
+          Back
+        </button>
+        <div className="flex flex-1 mt-8 overflow-hidden">
+          <div className="w-56 flex flex-col mr-4">
+            <button
+              onClick={handleAdd}
+              className="mb-2 bg-[#c08440] hover:bg-[#d69851] text-[#4d330e] border-2 border-[#633000] rounded-md p-1 font-bold"
+            >
+              New Note
+            </button>
+            <div className="flex-1 overflow-auto border-2 border-[#633000] rounded">
+              {notes.map((n) => (
+                <div
+                  key={n.title}
+                  className="flex items-center justify-between px-2 py-1 border-b border-[#633000] cursor-pointer"
+                  onClick={() => openNote(n.title)}
+                >
+                  <span>{n.title}</span>
+                  <span
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setDeleteTarget(n.title);
+                    }}
+                    className="text-red-600 ml-2"
+                  >
+                    x
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="flex-1 flex flex-col">
+            <input
+              value={currentTitle}
+              onChange={(e) => setCurrentTitle(e.target.value)}
+              className="border-[#633000] border-2 rounded mb-2 p-1 font-bold"
+            />
+            <textarea
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              className="flex-1 border-[#633000] border-2 rounded p-1 resize-none font-mono"
+            />
+            <button
+              onClick={handleSave}
+              className="mt-2 bg-[#c08440] hover:bg-[#d69851] text-[#4d330e] border-2 border-[#633000] rounded-md p-1 font-bold"
+            >
+              Save
+            </button>
+          </div>
+        </div>
+      </div>
+      <Modal
+        open={!!deleteTarget}
+        onCancel={() => setDeleteTarget(null)}
+        onOk={handleDelete}
+        okText="Delete"
+        cancelText="Cancel"
+        title="Delete note?"
+      >
+        <p>Are you sure you want to delete this note?</p>
+      </Modal>
+    </div>
+  );
+};
+
+export default Notes;
+


### PR DESCRIPTION
## Summary
- create `Notes` screen for editing markdown notes stored under `userData/notes`
- register IPC handlers in electron main process to manage notes
- add buttons in hidden capy view forming an arc; one opens notes screen
- add `/notes` route to application

## Testing
- `npm test` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b478a30e083249cf5219aa7ae1b24